### PR TITLE
remove netaddr dependency

### DIFF
--- a/defaults/main/0_hardcoded.yml
+++ b/defaults/main/0_hardcoded.yml
@@ -24,4 +24,3 @@ WG_HC:
   default_keepalive: 5
   log_output_lines: 10
   wg_svc: 'wg-quick'
-  controller_required_mods: ['netaddr']

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,0 @@
-# pip requirements
-netaddr

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -12,23 +12,6 @@
   when: "inventory_hostname not in wireguard.topologies | flatten_hosts"
   tags: [purge, tunnels, config]
 
-- name: Wireguard | Installing dependencies on controller
-  ansible.builtin.pip:
-    name: "{{ WG_HC.controller_required_mods }}"
-    state: present
-  delegate_to: localhost
-  register: install_controller_requirements
-  ignore_errors: true
-  become: false
-  run_once: true
-
-- name: Wireguard | Missing dependency
-  ansible.builtin.fail:
-    msg: "You need to install the python module 'netaddr' for this role to work correctly!"
-  when:
-    - install_controller_requirements.failed is defined
-    - install_controller_requirements.failed
-
 - name: Wireguard | Processing debian config
   ansible.builtin.import_tasks: debian/main.yml
   when: "ansible_distribution|lower in ['debian', 'ubuntu']"


### PR DESCRIPTION
I got some pip issues, as it is not recommended anymore since [PEP 668](https://peps.python.org/pep-0668/). My intend was to replace pip to package (as we deal with general Debian playbook) something like:

```
hc_packages:
 - 	python3-netaddr
```
```
    - name: install controller dependencies 
      ansible.builtin.package:
        name: "{{ hc_packages }}"
        update_cache: yes
        cache_valid_time: 86400
        state: present
      become: True      
```

However then I noticed netaddr is not in use (anymore?) maybe was it part of the filter plugin?

Anyway: very cool playbook, thank you for sharing!